### PR TITLE
Redesign UI with dark scoreboard theme, add settings edit mode

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,11 @@
+# Dev-only Firebase config. Safe to commit: the app runs against the local
+# emulator suite whenever DEV is true (see src/firebase/initializeFirebase.ts),
+# so these values are placeholders that just need to satisfy the SDK's format
+# checks — they are never used to talk to a real Firebase project.
+VITE_FIREBASE_API_KEY=demo-api-key
+VITE_FIREBASE_AUTH_DOMAIN=localhost
+VITE_FIREBASE_PROJECT_ID=points-tracker-929ca
+VITE_FIREBASE_STORAGE_BUCKET=points-tracker-929ca.appspot.com
+VITE_FIREBASE_MESSAGE_BUCKET=000000000000
+VITE_FIREBASE_APP_ID=demo-app-id
+VITE_FIREBASE_MEASUREMENT_ID=demo-measurement-id

--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0a0b10" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Manrope:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
     <title>Points Tracker</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,13 +31,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -56,21 +56,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -96,14 +96,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -113,14 +113,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -150,29 +150,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -212,27 +212,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -242,33 +242,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -276,35 +276,35 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1033,9 +1033,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "7.11.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.3.tgz",
-      "integrity": "sha512-qsM3/WHpawF07SRVvEJJVRwhYzM7o9qtuksyuqnrMig6fxIrwWnsezECWsG/D5TyYru51Fv5c/RTqNDQ2yU+4w==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
-      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -1105,8 +1105,7 @@
         "mime": "^3.0.0",
         "p-limit": "^3.0.1",
         "retry-request": "^7.0.0",
-        "teeny-request": "^9.0.0",
-        "uuid": "^8.0.0"
+        "teeny-request": "^9.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -1125,20 +1124,11 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.15",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
-      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -1393,21 +1383,37 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
@@ -1420,20 +1426,10 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@oxc-project/runtime": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
-      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1454,7 +1450,8 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
@@ -1462,33 +1459,30 @@
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
@@ -1501,14 +1495,15 @@
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -1523,9 +1518,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -1540,9 +1535,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -1557,9 +1552,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -1574,9 +1569,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -1591,9 +1586,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -1608,9 +1603,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -1625,9 +1620,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -1642,9 +1637,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -1659,9 +1654,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -1676,9 +1671,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -1693,9 +1688,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -1710,9 +1705,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -1720,16 +1715,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -1744,9 +1741,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -1768,19 +1765,20 @@
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2326,6 +2324,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -2381,13 +2393,16 @@
       ]
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bignumber.js": {
@@ -2400,9 +2415,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2423,9 +2438,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -2443,11 +2458,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2460,12 +2475,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001802",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
+      "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
       "dev": true,
       "funding": [
         {
@@ -2534,12 +2565,16 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/copy-anything": {
@@ -2630,6 +2665,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexify": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
@@ -2660,9 +2711,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2692,6 +2743,59 @@
       },
       "bin": {
         "errno": "cli.js"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2969,23 +3073,9 @@
       "dev": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
-      "integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
       "dev": true,
       "funding": [
         {
@@ -2996,8 +3086,30 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3122,9 +3234,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3135,9 +3247,7 @@
         "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
-        "uuid": "^11.0.2"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3215,20 +3325,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -3244,9 +3340,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3268,15 +3364,19 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
         "node": ">= 0.12"
@@ -3308,6 +3408,17 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/functional-red-black-tree": {
@@ -3365,6 +3476,47 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -3400,9 +3552,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3445,22 +3597,23 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.3.6.tgz",
-      "integrity": "sha512-z3MR+pE6WqU+tnKtkJl4c723EYY7Il4fcSNgEbehzUJpcNWkca9AyoC2pdBWmEa0cda21VRpUBb4s6VSATiUKg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@grpc/grpc-js": "~1.10.3",
+        "@grpc/grpc-js": "^1.10.9",
         "@grpc/proto-loader": "^0.7.13",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "google-auth-library": "^9.3.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.7.0",
         "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^2.0.0",
-        "protobufjs": "7.3.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
         "retry-request": "^7.0.0",
         "uuid": "^9.0.1"
       },
@@ -3469,17 +3622,38 @@
       }
     },
     "node_modules/google-gax/node_modules/@grpc/grpc-js": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
-      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
         "node": ">=12.10.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/google-logging-utils": {
@@ -3490,6 +3664,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -3511,6 +3699,51 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -3692,6 +3925,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/is-what": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
@@ -3813,33 +4060,36 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
@@ -3862,12 +4112,13 @@
       }
     },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4258,9 +4509,10 @@
       "dev": true
     },
     "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4322,6 +4574,17 @@
       "optional": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mime": {
@@ -4394,9 +4657,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -4477,21 +4740,15 @@
         }
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
@@ -4585,6 +4842,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4626,9 +4900,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4649,9 +4923,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -4669,7 +4943,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4700,23 +4974,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4786,9 +5060,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4808,12 +5082,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4888,14 +5162,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
-      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.115.0",
-        "@rolldown/pluginutils": "1.0.0-rc.9"
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4904,27 +5178,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
-      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4981,9 +5255,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -5122,9 +5396,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "dev": true,
       "funding": [
         {
@@ -5133,7 +5407,10 @@
         }
       ],
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/stubs": {
       "version": "3.0.0",
@@ -5187,14 +5464,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5323,18 +5600,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
-      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.9",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5350,8 +5626,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.0.0-alpha.31",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -5521,6 +5797,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/src/components/card/Card.module.less
+++ b/src/components/card/Card.module.less
@@ -1,18 +1,45 @@
 .card {
+  position: relative;
   display: flex;
   align-items: center;
-  background-color: #ffd4b5;
-  margin: 16px;
-  text-align: center;
-  font-size: 24px;
-  padding: 16px;
-  border-radius: 16px;
-  font-family: "Agency FB", serif;
-  min-height: 32px;
   justify-content: center;
+  margin: 24px 16px 32px;
+  padding: 28px 16px 24px;
+  text-align: center;
+  font-family: @font-display;
+  font-size: 42px;
+  letter-spacing: 0.05em;
+  color: @text-primary;
+  background: linear-gradient(180deg, @bg-surface-raised 0%, @bg-surface 100%);
+  border: 1px solid @border-subtle;
+  border-radius: @radius-lg;
+  box-shadow: @shadow-card;
+  min-height: 32px;
+  overflow: hidden;
 
-  &:hover {
-    background-color: #fdf3e5;
-    box-shadow: 0 0 3px #ffd4b5;
+  &::before {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    transform: translateX(-50%);
+    width: 72px;
+    height: 4px;
+    border-radius: @radius-pill;
+    background: @accent;
+    box-shadow: 0 0 16px @accent-glow;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: -40%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60%;
+    height: 140%;
+    background: radial-gradient(ellipse at center, @accent-glow, transparent 70%);
+    opacity: 0.4;
+    pointer-events: none;
   }
 }

--- a/src/components/eventSelector/EventSelector.tsx
+++ b/src/components/eventSelector/EventSelector.tsx
@@ -2,10 +2,10 @@ import styles from "../../styles/SharedSettingStyles.module.less";
 import SettingHeader from "../settingHeader/SettingHeader.tsx";
 import {MdOutlineArrowForwardIos} from "react-icons/md";
 import {Outlet, useNavigate, useParams} from "react-router-dom";
-import {useContext, useState} from "react";
+import {useContext, useEffect, useState} from "react";
 import {EventContext} from "../../contexts/EventContext.tsx";
-import {createNewEvent, removeEvent, setActiveEvent} from "../../firebase/services/eventService.ts";
-import {FaTrashAlt} from "react-icons/fa";
+import {createNewEvent, removeEvent, renameEvent, setActiveEvent} from "../../firebase/services/eventService.ts";
+import {FaCheck, FaPen, FaTimes, FaTrashAlt} from "react-icons/fa";
 
 const EventSelector = () => {
     const navigate = useNavigate();
@@ -14,6 +14,15 @@ const EventSelector = () => {
     const events = useContext(EventContext);
     const [addItem, setAddItem] = useState(false);
     const [newItemName, setNewItemName] = useState("");
+
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editValue, setEditValue] = useState("");
+
+    useEffect(() => {
+        if (!params.docId && !addItem && events.activeEvent) {
+            navigate(events.activeEvent.documentId, {replace: true});
+        }
+    }, [params.docId, addItem, events.activeEvent]);
 
     const goToRoute = async (route: string) => {
         navigate(route);
@@ -37,6 +46,23 @@ const EventSelector = () => {
         }
     }
 
+    const startEdit = (docId: string, currentName: string) => {
+        setEditingId(docId);
+        setEditValue(currentName);
+    }
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setEditValue("");
+    }
+
+    const saveEdit = async (docId: string) => {
+        if (editValue.trim().length > 0) {
+            await renameEvent(docId, editValue.trim());
+        }
+        cancelEdit();
+    }
+
     return (
         <>
             <div className={styles.category}>
@@ -48,14 +74,49 @@ const EventSelector = () => {
                     {
                         events.allEvents.map((event) => (
                             <div className={`${styles.listItem} ${params.docId === event.documentId && styles.active}`}
-                                 onClick={() => goToRoute(event.documentId)} key={event.documentId}>
+                                 onClick={() => editingId !== event.documentId && goToRoute(event.documentId)}
+                                 key={event.documentId}>
                                 <div className={styles.name}>
                                     <FaTrashAlt className={styles.deleteIcon}
-                                                onClick={() => deleteEvent(event.documentId)}/>
-                                    {event.name}
-                                    <small
-                                        onClick={() => changeActiveEvent(event.documentId, event.isActive)}>({event.isActive ? 'Currently Active' : 'Make active event'})</small>
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    deleteEvent(event.documentId);
+                                                }}/>
+                                    {
+                                        editingId === event.documentId ? (
+                                            <input type="text" className={styles.editInput} autoFocus
+                                                   value={editValue}
+                                                   onClick={(e) => e.stopPropagation()}
+                                                   onChange={(e) => setEditValue(e.target.value)}
+                                                   onKeyDown={(e) => {
+                                                       if (e.key === "Enter") saveEdit(event.documentId);
+                                                       if (e.key === "Escape") cancelEdit();
+                                                   }}/>
+                                        ) : (
+                                            <span className={styles.nameText}>{event.name}</span>
+                                        )
+                                    }
                                 </div>
+                                {
+                                    editingId === event.documentId ? (
+                                        <div className={styles.editActions} onClick={(e) => e.stopPropagation()}>
+                                            <FaCheck className={styles.saveIcon} onClick={() => saveEdit(event.documentId)}/>
+                                            <FaTimes className={styles.cancelIcon} onClick={cancelEdit}/>
+                                        </div>
+                                    ) : (
+                                        <FaPen className={styles.editIcon}
+                                               onClick={(e) => {
+                                                   e.stopPropagation();
+                                                   startEdit(event.documentId, event.name);
+                                               }}/>
+                                    )
+                                }
+                                <small
+                                    className={event.isActive ? styles.activePill : styles.inactivePill}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        changeActiveEvent(event.documentId, event.isActive);
+                                    }}>{event.isActive ? 'Actief' : 'Maak actief'}</small>
                                 <div>
                                     <MdOutlineArrowForwardIos/>
                                 </div>

--- a/src/components/gameSetting/GameSetting.tsx
+++ b/src/components/gameSetting/GameSetting.tsx
@@ -4,12 +4,15 @@ import {useContext, useState} from "react";
 import {EventContext} from "../../contexts/EventContext.tsx";
 import {GameContext} from "../../contexts/GameContext.tsx";
 import {useParams} from "react-router-dom";
-import {createNewGame, removeGame} from "../../firebase/services/gameService.ts";
-import {FaTrashAlt} from "react-icons/fa";
+import {createNewGame, removeGame, renameGame} from "../../firebase/services/gameService.ts";
+import {FaCheck, FaPen, FaTimes, FaTrashAlt} from "react-icons/fa";
 
 const GameSetting = () => {
     const [addItem, setAddItem] = useState<boolean>(false);
     const [newGameName, setNewGameName] = useState<string>("");
+
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editValue, setEditValue] = useState("");
 
     const {activeEvent, hasActiveEvent} = useContext(EventContext);
     const {allGames} = useContext(GameContext);
@@ -27,6 +30,23 @@ const GameSetting = () => {
         await removeGame(docId)
     }
 
+    const startEdit = (docId: string, currentName: string) => {
+        setEditingId(docId);
+        setEditValue(currentName);
+    }
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setEditValue("");
+    }
+
+    const saveEdit = async (docId: string) => {
+        if (editValue.trim().length > 0) {
+            await renameGame(docId, editValue.trim());
+        }
+        cancelEdit();
+    }
+
     return (
         <div className={styles.category}>
             <SettingHeader title="Game"
@@ -39,8 +59,31 @@ const GameSetting = () => {
                         <div className={`${styles.listItem}`} key={game.documentId}>
                             <div className={styles.name}>
                                 <FaTrashAlt className={styles.deleteIcon} onClick={() => deleteGame(game.documentId)}/>
-                                {game.name}
+                                {
+                                    editingId === game.documentId ? (
+                                        <input type="text" className={styles.editInput} autoFocus
+                                               value={editValue}
+                                               onChange={(e) => setEditValue(e.target.value)}
+                                               onKeyDown={(e) => {
+                                                   if (e.key === "Enter") saveEdit(game.documentId);
+                                                   if (e.key === "Escape") cancelEdit();
+                                               }}/>
+                                    ) : (
+                                        <span className={styles.nameText}>{game.name}</span>
+                                    )
+                                }
                             </div>
+                            {
+                                editingId === game.documentId ? (
+                                    <div className={styles.editActions}>
+                                        <FaCheck className={styles.saveIcon} onClick={() => saveEdit(game.documentId)}/>
+                                        <FaTimes className={styles.cancelIcon} onClick={cancelEdit}/>
+                                    </div>
+                                ) : (
+                                    <FaPen className={styles.editIcon}
+                                           onClick={() => startEdit(game.documentId, game.name)}/>
+                                )
+                            }
                         </div>
                     ))
                 }

--- a/src/components/settingHeader/SettingHeader.module.less
+++ b/src/components/settingHeader/SettingHeader.module.less
@@ -2,20 +2,29 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid darkgray;
-  padding: 16px;
+  border-bottom: 1px solid @border-subtle;
+  padding: 16px 20px;
 
   .itemHeader {
-    font-family: "Agency FB", serif;
-    font-size: 24px;
-    font-weight: bold;
-    padding: 4px;
+    font-family: @font-display;
+    font-size: 22px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: @text-primary;
   }
 
   .addIcon {
-    .icon:hover {
-      color: darkgray;
-      cursor: pointer;
+    display: flex;
+
+    .icon {
+      color: @accent;
+      transition: color @transition-fast, transform @transition-fast;
+
+      &:hover {
+        color: @text-primary;
+        transform: scale(1.08) rotate(90deg);
+        cursor: pointer;
+      }
     }
   }
 }

--- a/src/components/teamSetting/TeamSetting.tsx
+++ b/src/components/teamSetting/TeamSetting.tsx
@@ -1,15 +1,18 @@
 import styles from "../../styles/SharedSettingStyles.module.less";
 import SettingHeader from "../settingHeader/SettingHeader.tsx";
 import {useContext, useState} from "react";
-import {createNewTeam, removeTeam} from "../../firebase/services/teamService.ts";
+import {createNewTeam, removeTeam, renameTeam} from "../../firebase/services/teamService.ts";
 import {EventContext} from "../../contexts/EventContext.tsx";
 import {TeamContext} from "../../contexts/TeamContext.tsx";
-import {FaTrashAlt} from "react-icons/fa";
+import {FaCheck, FaPen, FaTimes, FaTrashAlt} from "react-icons/fa";
 import {useParams} from "react-router-dom";
 
 const TeamSetting = () => {
     const [addItem, setAddItem] = useState(false);
     const [newTeamName, setNewTeamName] = useState("");
+
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editValue, setEditValue] = useState("");
 
     const {activeEvent, hasActiveEvent} = useContext(EventContext);
     const {allTeams} = useContext(TeamContext);
@@ -27,6 +30,23 @@ const TeamSetting = () => {
         await removeTeam(docId);
     }
 
+    const startEdit = (docId: string, currentName: string) => {
+        setEditingId(docId);
+        setEditValue(currentName);
+    }
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setEditValue("");
+    }
+
+    const saveEdit = async (docId: string) => {
+        if (editValue.trim().length > 0) {
+            await renameTeam(docId, editValue.trim());
+        }
+        cancelEdit();
+    }
+
     return (
         <div className={styles.category}>
             <SettingHeader title="Team" canAddItem={!addItem && hasActiveEvent}
@@ -37,8 +57,31 @@ const TeamSetting = () => {
                         <div className={`${styles.listItem}`} key={team.documentId}>
                             <div className={styles.name}>
                                 <FaTrashAlt className={styles.deleteIcon} onClick={() => deleteTeam(team.documentId)}/>
-                                {team.name}
+                                {
+                                    editingId === team.documentId ? (
+                                        <input type="text" className={styles.editInput} autoFocus
+                                               value={editValue}
+                                               onChange={(e) => setEditValue(e.target.value)}
+                                               onKeyDown={(e) => {
+                                                   if (e.key === "Enter") saveEdit(team.documentId);
+                                                   if (e.key === "Escape") cancelEdit();
+                                               }}/>
+                                    ) : (
+                                        <span className={styles.nameText}>{team.name}</span>
+                                    )
+                                }
                             </div>
+                            {
+                                editingId === team.documentId ? (
+                                    <div className={styles.editActions}>
+                                        <FaCheck className={styles.saveIcon} onClick={() => saveEdit(team.documentId)}/>
+                                        <FaTimes className={styles.cancelIcon} onClick={cancelEdit}/>
+                                    </div>
+                                ) : (
+                                    <FaPen className={styles.editIcon}
+                                           onClick={() => startEdit(team.documentId, team.name)}/>
+                                )
+                            }
                         </div>
                     ))
                 }

--- a/src/firebase/services/eventService.ts
+++ b/src/firebase/services/eventService.ts
@@ -1,4 +1,4 @@
-import {addDoc, collection, deleteDoc, doc, writeBatch} from "firebase/firestore"
+import {addDoc, collection, deleteDoc, doc, updateDoc, writeBatch} from "firebase/firestore"
 import {db} from "../initializeFirebase.ts";
 import {collections} from "../collections.ts";
 import {removeTeamsForEvent} from "./teamService.ts";
@@ -10,6 +10,10 @@ export const createNewEvent = async (eventName: string) => {
         name: eventName,
         isActive: false
     });
+}
+
+export const renameEvent = async (documentId: string, eventName: string) => {
+    await updateDoc(doc(db, collections.events, documentId), {name: eventName});
 }
 
 export const removeEvent = async (documentId: string) => {

--- a/src/firebase/services/gameService.ts
+++ b/src/firebase/services/gameService.ts
@@ -1,4 +1,4 @@
-import {addDoc, collection, deleteDoc, doc, getDocs, query, where, writeBatch} from "firebase/firestore";
+import {addDoc, collection, deleteDoc, doc, getDocs, query, updateDoc, where, writeBatch} from "firebase/firestore";
 import {db} from "../initializeFirebase.ts";
 import {collections} from "../collections.ts";
 
@@ -7,6 +7,10 @@ export const createNewGame = async (gameName: string, eventDocumentId: string) =
         name: gameName,
         eventDocumentId: eventDocumentId,
     });
+}
+
+export const renameGame = async (documentId: string, gameName: string) => {
+    await updateDoc(doc(db, collections.games, documentId), {name: gameName});
 }
 
 export const removeGame = async (documentId: string) => {

--- a/src/firebase/services/teamService.ts
+++ b/src/firebase/services/teamService.ts
@@ -1,4 +1,4 @@
-import {addDoc, collection, deleteDoc, doc, getDocs, query, where, writeBatch} from "firebase/firestore";
+import {addDoc, collection, deleteDoc, doc, getDocs, query, updateDoc, where, writeBatch} from "firebase/firestore";
 import {db} from "../initializeFirebase.ts";
 import {collections} from "../collections.ts";
 
@@ -7,6 +7,10 @@ export const createNewTeam = async (teamName: string, eventDocumentId: string) =
         name: teamName,
         eventDocumentId: eventDocumentId,
     });
+}
+
+export const renameTeam = async (documentId: string, teamName: string) => {
+    await updateDoc(doc(db, collections.teams, documentId), {name: teamName});
 }
 
 export const removeTeam = async (documentId: string) => {

--- a/src/index.css
+++ b/src/index.css
@@ -5,15 +5,68 @@
 
 html {
   box-sizing: border-box;
+  color-scheme: dark;
 }
 
 *, *:before, *:after {
   box-sizing: inherit;
 }
 
-:root {
-  height: 100vh;
-  width: 100vw;
+html, body, #root {
+  min-height: 100vh;
+  width: 100%;
+}
 
-  background-color: #feffdb;
+body {
+  font-family: "Manrope", "Segoe UI", sans-serif;
+  color: #f5f4ef;
+  background-color: #07080d;
+  background-image:
+    radial-gradient(ellipse 900px 500px at 50% -10%, rgba(198, 255, 53, 0.10), transparent 60%),
+    radial-gradient(ellipse 700px 500px at 100% 10%, rgba(255, 214, 10, 0.05), transparent 55%),
+    radial-gradient(ellipse 700px 500px at 0% 30%, rgba(255, 84, 104, 0.05), transparent 55%);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
+  position: relative;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+a {
+  color: inherit;
+}
+
+button, input {
+  font-family: inherit;
+}
+
+::selection {
+  background: rgba(198, 255, 53, 0.35);
+  color: #0c1103;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: #0e0f17;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #2a2e40;
+  border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #3a3f56;
 }

--- a/src/pages/dashboard/Dashboard.module.less
+++ b/src/pages/dashboard/Dashboard.module.less
@@ -1,60 +1,175 @@
 .app {
   display: flex;
   flex-direction: column;
+  max-width: 760px;
+  margin: 0 auto;
+  min-height: 100vh;
+  padding-bottom: 16px;
 
   .pointOverview {
-    .teamDiv {
-      padding: 16px;
-      border-bottom: 1px solid darkgray;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0 16px;
 
-      &:first-child {
-        border-top: 1px solid darkgray;
-      }
+    .teamDiv {
+      .surface-card();
+      padding: 0;
+      cursor: pointer;
+      transition: transform @transition-fast, border-color @transition-fast, box-shadow @transition-fast;
+      border-left: 4px solid transparent;
+      animation: rise 0.4s @ease backwards;
 
       &:hover {
-        background-color: rgba(0, 0, 0, 0.15)
+        transform: translateY(-2px);
+        border-color: @border-strong;
+      }
+
+      &.rank1 {
+        border-left-color: @medal-gold;
+        box-shadow: 0 4px 28px rgba(255, 214, 10, 0.12);
+
+        .rank {
+          color: @medal-gold;
+        }
+      }
+
+      &.rank2 {
+        border-left-color: @medal-silver;
+
+        .rank {
+          color: @medal-silver;
+        }
+      }
+
+      &.rank3 {
+        border-left-color: @medal-bronze;
+
+        .rank {
+          color: @medal-bronze;
+        }
       }
 
       .teamContainer {
-        flex: 1;
         display: flex;
-        justify-content: space-between;
         align-items: center;
+        gap: 16px;
+        padding: 18px 20px;
+
+        .rank {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-family: @font-display;
+          font-size: 30px;
+          letter-spacing: 0.02em;
+          color: @text-dim;
+          min-width: 64px;
+
+          .crownIcon {
+            font-size: 18px;
+            color: @medal-gold;
+            filter: drop-shadow(0 0 6px rgba(255, 214, 10, 0.6));
+          }
+        }
 
         .teamName {
-          font-family: "Agency FB", serif;
-          font-size: 24px;
+          flex: 1;
+          font-family: @font-body;
+          font-weight: 700;
+          font-size: 18px;
+          color: @text-primary;
+        }
 
-          b {
-            font-size: 28px;
-            margin-right: 8px;
-          }
+        .points {
+          font-family: @font-display;
+          font-size: 26px;
+          letter-spacing: 0.02em;
+          color: @accent;
 
-          i {
-            margin-left: 16px;
+          small {
+            margin-left: 4px;
+            font-family: @font-body;
+            font-weight: 700;
+            font-size: 12px;
+            color: @text-dim;
+            text-transform: uppercase;
           }
         }
 
         .teamIcon {
           font-size: 24px;
+          color: @text-dim;
+          flex-shrink: 0;
         }
       }
 
       .subContainer {
-        margin-left: 16px;
-        font-family: "Agency FB", serif;
-        font-size: 16px;
+        padding: 4px 20px 16px 100px;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
 
         .container {
+          display: flex;
+          justify-content: space-between;
+          padding: 8px 0;
+          border-top: 1px solid @border-subtle;
+          font-family: @font-body;
+          font-size: 14px;
+          color: @text-muted;
+          font-weight: 600;
+
           i {
-            margin-left: 8px;
+            font-style: normal;
+            color: @text-dim;
           }
         }
+      }
+    }
+
+    .emptyState {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+      padding: 64px 16px;
+      color: @text-dim;
+
+      .emptyIcon {
+        font-size: 40px;
+      }
+
+      p {
+        font-family: @font-body;
+        font-weight: 600;
       }
     }
   }
 
   .copyright {
+    margin-top: auto;
+    padding-top: 24px;
     text-align: center;
+    color: @text-dim;
+    font-size: 12px;
+  }
+}
+
+.pointOverview .teamDiv:nth-child(1) { animation-delay: 0.02s; }
+.pointOverview .teamDiv:nth-child(2) { animation-delay: 0.06s; }
+.pointOverview .teamDiv:nth-child(3) { animation-delay: 0.1s; }
+.pointOverview .teamDiv:nth-child(4) { animation-delay: 0.14s; }
+.pointOverview .teamDiv:nth-child(5) { animation-delay: 0.18s; }
+.pointOverview .teamDiv:nth-child(n+6) { animation-delay: 0.22s; }
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -3,43 +3,56 @@ import Card from "../../components/card/Card.tsx";
 import {EventContext} from "../../contexts/EventContext.tsx";
 import {useContext, useState} from "react";
 import {DashboardContext, getSortedData} from "../../contexts/DashboardContext.tsx";
-import {MdOutlineArrowDropDown, MdOutlineArrowDropUp} from "react-icons/md";
+import {MdOutlineArrowDropDown, MdOutlineArrowDropUp, MdOutlineLeaderboard} from "react-icons/md";
+import {FaCrown} from "react-icons/fa";
 
 const Dashboard = () => {
-    const {activeEvent} = useContext(EventContext);
+    const {activeEvent, hasActiveEvent} = useContext(EventContext);
     const data = useContext(DashboardContext);
 
     const [openedTeam, setOpenedTeam] = useState<string>("");
 
     const switchOpenedTeam = (teamKey: string) => setOpenedTeam(() => openedTeam === teamKey ? "" : teamKey);
 
+    const sortedData = getSortedData(data);
+
     const CURRENT_YEAR = new Date().getFullYear();
     return (
         <div className={styles.app}>
-            <Card title={activeEvent?.name ?? ""}/>
+            <Card title={activeEvent?.name ?? "Points Tracker"}/>
             <div className={styles.pointOverview}>
                 {
-                    getSortedData(data).map((obj) => (
-                        <div className={styles.teamDiv} key={obj.teamName}
-                             onClick={() => switchOpenedTeam(obj.teamName)}>
+                    hasActiveEvent && sortedData.length > 0 ? sortedData.map((obj) => (
+                        <div
+                            className={`${styles.teamDiv} ${obj.rank <= 3 ? styles[`rank${obj.rank}`] : ""}`}
+                            key={obj.teamName}
+                            onClick={() => switchOpenedTeam(obj.teamName)}>
                             <div className={styles.teamContainer}>
-                                <div className={styles.teamName}>
-                                    <b>#{obj.rank}</b>
-                                    {obj.teamName}
-                                    <i>({obj.totalPoints} punten)</i></div>
-                                {openedTeam === obj.teamName ? <MdOutlineArrowDropUp className={styles.teamIcon}/> :
+                                <div className={styles.rank}>
+                                    {obj.rank === 1 && <FaCrown className={styles.crownIcon}/>}
+                                    <span>#{obj.rank}</span>
+                                </div>
+                                <div className={styles.teamName}>{obj.teamName}</div>
+                                <div className={styles.points}>{obj.totalPoints}<small>pt</small></div>
+                                {openedTeam === obj.teamName ?
+                                    <MdOutlineArrowDropUp className={styles.teamIcon}/> :
                                     <MdOutlineArrowDropDown className={styles.teamIcon}/>}
                             </div>
                             {openedTeam === obj.teamName && <div className={styles.subContainer}>
                                 {Object.keys(obj.games).map(gameKey => (
                                     <div key={gameKey} className={styles.container}>
-                                        {obj.games[gameKey].gameName}
-                                        <i>({obj.games[gameKey].points} punten)</i>
+                                        <span>{obj.games[gameKey].gameName}</span>
+                                        <i>{obj.games[gameKey].points} punten</i>
                                     </div>
                                 ))}
                             </div>}
                         </div>
-                    ))
+                    )) : (
+                        <div className={styles.emptyState}>
+                            <MdOutlineLeaderboard className={styles.emptyIcon}/>
+                            <p>Nog geen scores om te tonen.</p>
+                        </div>
+                    )
                 }
             </div>
             <div className={styles.copyright}>&copy; 2024-{CURRENT_YEAR} Bas Mulder</div>

--- a/src/pages/points/Points.module.less
+++ b/src/pages/points/Points.module.less
@@ -1,92 +1,183 @@
 .container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  max-width: 760px;
+  margin: 0 auto;
+
   .header {
-    background-color: #ffd4b5;
-    padding: 16px;
+    background: @bg-surface;
+    border-bottom: 1px solid @border-subtle;
+    padding: 16px 20px;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+
+    .welcome {
+      font-family: @font-body;
+      font-weight: 700;
+      font-size: 14px;
+      color: @text-muted;
+    }
+
+    .navLinks {
+      display: flex;
+      gap: 8px;
+    }
 
     .link {
-      margin-right: 8px;
+      .btn-ghost();
+      font-size: 13px;
       text-decoration: none;
-      color: white;
-      background-color: blueviolet;
-      padding: 8px;
-      border-radius: 4px;
-      box-shadow: #e4afff 1px 1px 1px;
 
-      &:hover {
-        box-shadow: black 2px 2px 2px;
+      svg {
+        font-size: 16px;
       }
     }
 
     .button {
-      border: none;
-      background-color: blueviolet;
-      padding: 8px;
-      border-radius: 4px;
-      color: white;
-      box-shadow: #e4afff 1px 1px 1px;
+      .btn-ghost();
+      font-size: 13px;
+      color: @danger;
+      border-color: fade(@danger, 35%);
+
+      svg {
+        font-size: 16px;
+      }
 
       &:hover {
-        box-shadow: black 2px 2px 2px;
+        color: @danger;
+        border-color: @danger;
+        background: fade(@danger, 10%);
       }
     }
   }
 
   .eventName {
     text-align: center;
-    font-size: 32px;
-    font-weight: bold;
-    font-family: "Agency FB", serif;
+    font-size: 34px;
+    font-weight: 400;
+    font-family: @font-display;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
     cursor: pointer;
+    padding: 24px 16px 8px;
+    color: @text-primary;
   }
 
   .gameName {
     text-align: center;
     font-size: 24px;
-    font-family: "Agency FB", serif;
+    font-family: @font-display;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: @text-primary;
+    padding: 8px 16px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    position: relative;
+
+    .backButton {
+      .btn-reset();
+      position: absolute;
+      left: 16px;
+      display: flex;
+      align-items: center;
+      color: @text-muted;
+      font-size: 18px;
+      padding: 8px;
+      border-radius: @radius-pill;
+      transition: color @transition-fast, background @transition-fast;
+
+      &:hover {
+        color: @text-primary;
+        background: @bg-surface-raised;
+      }
+    }
+  }
+
+  .teamList {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 0 16px;
   }
 
   .game {
-    padding: 16px;
+    .surface-card();
+    padding: 16px 20px;
     display: flex;
     justify-content: space-between;
-    border-bottom: 1px solid black;
+    align-items: center;
     cursor: pointer;
+    margin: 0 16px 10px;
+    transition: transform @transition-fast, border-color @transition-fast;
 
     &:hover {
-      background-color: rgba(0, 0, 0, 0.25);
+      transform: translateY(-1px);
+      border-color: @border-strong;
+    }
+
+    .gameLabel {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-family: @font-body;
+      font-weight: 700;
+      font-size: 16px;
+      color: @text-primary;
+
+      svg {
+        color: @accent;
+        font-size: 18px;
+      }
+    }
+
+    > svg {
+      color: @text-dim;
+      font-size: 16px;
+      flex-shrink: 0;
     }
 
     .input {
-      border: none;
-      outline: none;
-      background-color: transparent;
-      border-bottom: 1px solid darkgray;
-      margin-left: 16px;
-      flex: 1;
+      .text-input();
+      width: 96px;
+      text-align: right;
+      font-family: @font-display;
+      font-size: 20px;
+      letter-spacing: 0.02em;
     }
+  }
+
+  .teamList .game {
+    margin: 0;
   }
 
   .submitButton {
-    width: 100%;
-    border: none;
-    background-color: blueviolet;
-    padding: 8px;
-    color: white;
-    box-shadow: #e4afff 1px 1px 1px;
+    .btn-primary();
+    margin: 20px 16px 0;
+    padding: 16px;
+    font-size: 15px;
+    text-transform: uppercase;
+  }
 
-    &:hover {
-      box-shadow: black 2px 2px 2px;
-    }
-
-    &:disabled {
-      background-color: gray;
-    }
+  .emptyState {
+    text-align: center;
+    color: @text-dim;
+    font-family: @font-body;
+    font-weight: 600;
+    padding: 48px 16px;
   }
 
   .copyright {
+    margin-top: auto;
+    padding: 24px 16px 16px;
     text-align: center;
+    color: @text-dim;
+    font-size: 12px;
   }
 }

--- a/src/pages/points/Points.tsx
+++ b/src/pages/points/Points.tsx
@@ -6,7 +6,15 @@ import {auth} from "../../firebase/initializeFirebase.ts";
 import styles from "./Points.module.less";
 import {GameContext} from "../../contexts/GameContext.tsx";
 import {EventContext} from "../../contexts/EventContext.tsx";
-import {MdOutlineArrowForwardIos} from "react-icons/md";
+import {
+    MdOutlineArrowBackIos,
+    MdOutlineArrowForwardIos,
+    MdOutlineDashboard,
+    MdOutlineLogout,
+    MdOutlineSettings,
+    MdOutlineSportsEsports
+} from "react-icons/md";
+import {IoSaveOutline} from "react-icons/io5";
 import {TeamContext} from "../../contexts/TeamContext.tsx";
 import {addPointsForGame} from "../../firebase/services/pointService.ts";
 import {PointContext} from "../../contexts/PointContext.tsx";
@@ -122,52 +130,59 @@ const Points = () => {
     return (
         <div className={styles.container}>
             <div className={styles.header}>
-                Welkom, {user?.email}
-                <div>
-                    <Link to="/" className={styles.link}>Dashboard</Link>
-                    <Link className={styles.link} to="/settings">Settings</Link>
-                    <button onClick={logOut} className={styles.button}>Sign out</button>
+                <span className={styles.welcome}>Welkom, {user?.email}</span>
+                <div className={styles.navLinks}>
+                    <Link to="/" className={styles.link}><MdOutlineDashboard/> Dashboard</Link>
+                    <Link className={styles.link} to="/settings"><MdOutlineSettings/> Settings</Link>
+                    <button onClick={logOut} className={styles.button}><MdOutlineLogout/> Sign out</button>
                 </div>
             </div>
             {
-                hasActiveEvent && (<>
+                hasActiveEvent ? (<>
                         <div className={styles.eventName} onClick={() => setSelectedGame(null)}>
                             <p>{activeEvent?.name}</p>
                         </div>
                         {
-                            selectedGame === null ? gamesInThisEvent.map((game) => (
-                                <div key={game.documentId} className={styles.game}
-                                     onClick={() => navigateToGame(game.documentId)}>
-                                    {game.name}
-                                    <MdOutlineArrowForwardIos/>
-                                </div>
-                            )) : (
-                                <>
-                                    <div
-                                        className={styles.gameName}>{gamesInThisEvent.find(g => g.documentId === selectedGame)?.name}
+                            selectedGame === null ? (
+                                gamesInThisEvent.length > 0 ? gamesInThisEvent.map((game) => (
+                                    <div key={game.documentId} className={styles.game}
+                                         onClick={() => navigateToGame(game.documentId)}>
+                                        <span className={styles.gameLabel}><MdOutlineSportsEsports/> {game.name}</span>
+                                        <MdOutlineArrowForwardIos/>
                                     </div>
-                                    {
-                                        teamsInThisEvent.map((team) => (
-                                            <div key={team.documentId} className={styles.game}>
-                                                {team.name}
-                                                <input type="number" className={styles.input}
-                                                       placeholder={`Type here the points for ${team.name}`}
-                                                       onChange={(e) => updatePoints(selectedGame, team.documentId, parseInt(e.target.value))}
-                                                       value={getValueOrNull(selectedGame, team.documentId) || ""}
-                                                />
-                                            </div>
-                                        ))
-                                    }
+                                )) : <div className={styles.emptyState}>Nog geen spellen toegevoegd.</div>
+                            ) : (
+                                <>
+                                    <div className={styles.gameName}>
+                                        <button className={styles.backButton} onClick={() => setSelectedGame(null)}>
+                                            <MdOutlineArrowBackIos/>
+                                        </button>
+                                        {gamesInThisEvent.find(g => g.documentId === selectedGame)?.name}
+                                    </div>
+                                    <div className={styles.teamList}>
+                                        {
+                                            teamsInThisEvent.map((team) => (
+                                                <div key={team.documentId} className={styles.game}>
+                                                    <span className={styles.gameLabel}>{team.name}</span>
+                                                    <input type="number" className={styles.input}
+                                                           placeholder="0"
+                                                           onChange={(e) => updatePoints(selectedGame, team.documentId, parseInt(e.target.value))}
+                                                           value={getValueOrNull(selectedGame, team.documentId) || ""}
+                                                    />
+                                                </div>
+                                            ))
+                                        }
+                                    </div>
                                     <button className={styles.submitButton}
                                             disabled={Object.keys(pointsForGame[selectedGame] || {}).length !== teamsInThisEvent.length || !hasActiveEvent}
                                             onClick={() => persistPoints()}
-                                    >Save
+                                    ><IoSaveOutline/> Opslaan
                                     </button>
                                 </>
                             )
                         }
                     </>
-                )
+                ) : <div className={styles.emptyState}>Geen actief evenement.</div>
             }
             <div className={styles.copyright}>&copy; 2024-{CURRENT_YEAR} Bas Mulder</div>
         </div>

--- a/src/pages/settings/Settings.module.less
+++ b/src/pages/settings/Settings.module.less
@@ -1,77 +1,147 @@
 .container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 
   .header {
-    background-color: #ffd4b5;
-    padding: 16px;
+    background: @bg-surface;
+    border-bottom: 1px solid @border-subtle;
+    padding: 16px 20px;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+
+    .welcome {
+      font-family: @font-body;
+      font-weight: 700;
+      font-size: 14px;
+      color: @text-muted;
+      flex: 1 1 140px;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .navLinks {
+      display: flex;
+      gap: 8px;
+    }
 
     .link {
-      margin-right: 8px;
+      .btn-ghost();
+      font-size: 13px;
       text-decoration: none;
-      color: white;
-      background-color: blueviolet;
-      padding: 8px;
-      border-radius: 4px;
-      box-shadow: #e4afff 1px 1px 1px;
-
-      &:hover {
-        box-shadow: black 2px 2px 2px;
-      }
     }
 
     .button {
-      border: none;
-      background-color: blueviolet;
-      padding: 8px;
-      border-radius: 4px;
-      color: white;
-      box-shadow: #e4afff 1px 1px 1px;
+      .btn-ghost();
+      font-size: 13px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: @danger;
+      border-color: fade(@danger, 35%);
 
       &:hover {
-        box-shadow: black 2px 2px 2px;
+        color: @danger;
+        border-color: @danger;
+        background: fade(@danger, 10%);
       }
     }
   }
 
   .navigator {
     display: flex;
-    background-color: #e4afff;
-    justify-content: space-evenly;
-    align-items: center;
-    text-align: start;
+    background: @bg-base;
+    border-bottom: 1px solid @border-subtle;
 
-    .link {
+    .tab {
       flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
       padding: 16px;
-      font-family: Arial, serif;
-      font-weight: normal;
-      border-bottom: 1px solid darkgray;
+      font-family: @font-body;
+      font-weight: 700;
+      font-size: 14px;
+      color: @text-muted;
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      transition: color @transition-fast, border-color @transition-fast, background @transition-fast;
 
-      &:hover, &.active {
-        text-decoration: underline;
-        background-color: #b691cf;
+      svg {
+        font-size: 17px;
+      }
+
+      &:hover {
+        color: @text-primary;
+        background: @bg-surface;
+      }
+
+      &.active {
+        color: @accent;
+        border-bottom-color: @accent;
+        background: @bg-surface;
       }
 
       &:not(:last-child) {
-        border-right: 1px solid darkgray;
+        border-right: 1px solid @border-subtle;
       }
-    }
-
-    a {
-      background-color: blueviolet;
     }
   }
 
   .content {
+    flex: 1;
     display: flex;
     flex-direction: row;
-    justify-content: space-evenly;
-    background-color: #fdf3e5;
+    align-items: flex-start;
+    justify-content: center;
+    background: @bg-base;
+    padding: 24px 16px;
+    gap: 24px;
+    flex-wrap: wrap;
   }
 
   .copyright {
     text-align: center;
+    color: @text-dim;
+    font-size: 12px;
+    padding: 16px;
+    background: @bg-base;
+  }
+
+  @media (max-width: 480px) {
+    .header {
+      padding: 12px 16px;
+      gap: 10px;
+    }
+
+    .navLinks {
+      gap: 6px;
+    }
+
+    .link, .button {
+      padding: 8px 12px;
+      font-size: 12px;
+    }
+
+    .tab {
+      padding: 12px 8px;
+      gap: 6px;
+      font-size: 12px;
+
+      svg {
+        font-size: 15px;
+      }
+    }
+
+    .content {
+      padding: 16px 12px;
+      gap: 16px;
+    }
   }
 }

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -4,6 +4,8 @@ import {Link, Outlet, useLocation, useNavigate} from "react-router-dom";
 import {signOut} from "firebase/auth";
 import {auth} from "../../firebase/initializeFirebase.ts";
 import styles from "./Settings.module.less"
+import {MdOutlineLogout, MdOutlineSportsEsports} from "react-icons/md";
+import {IoPeopleOutline} from "react-icons/io5";
 
 const Settings = () => {
     const {user, isLoggedIn, loading} = useContext(UserContext);
@@ -22,8 +24,6 @@ const Settings = () => {
 
     useEffect(() => {
         if (!loading && !isLoggedIn) {
-            alert(loading)
-            alert(isLoggedIn)
             navigate("/login");
         }
 
@@ -32,26 +32,26 @@ const Settings = () => {
     return (
         <div className={styles.container}>
             <div className={styles.header}>
-                Welkom, {user?.email}
-                <div>
+                <span className={styles.welcome}>Welkom, {user?.email}</span>
+                <div className={styles.navLinks}>
                     <Link to="/points" className={styles.link}>Points</Link>
-                    <button onClick={logOut} className={styles.button}>SignOut</button>
+                    <button onClick={logOut} className={styles.button}><MdOutlineLogout/> Sign out</button>
                 </div>
             </div>
             <div className={styles.navigator}>
-                <div className={`${styles.link} ${hasSubPath("teams") && styles.active}`}
+                <div className={`${styles.tab} ${hasSubPath("teams") ? styles.active : ""}`}
                      onClick={() => navigateToSetting("teams")}>
-                    Team Settings
+                    <IoPeopleOutline/> Team Settings
                 </div>
-                <div className={`${styles.link} ${hasSubPath("games") && styles.active}`}
+                <div className={`${styles.tab} ${hasSubPath("games") ? styles.active : ""}`}
                      onClick={() => navigateToSetting("games")}>
-                    Games
+                    <MdOutlineSportsEsports/> Games
                 </div>
             </div>
             <div className={styles.content}>
                 <Outlet/>
             </div>
-            <div className={styles.copyright}>&copy; 2024 Bas Mulder</div>
+            <div className={styles.copyright}>&copy; 2024-{new Date().getFullYear()} Bas Mulder</div>
         </div>
     )
 }

--- a/src/pages/signin/SignIn.module.less
+++ b/src/pages/signin/SignIn.module.less
@@ -1,52 +1,100 @@
 .container {
   margin: 0;
-  padding: 0;
-  height: 100vh;
+  padding: 24px 16px;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 32px;
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: @font-display;
+    font-size: 32px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: @text-primary;
+
+    .brandIcon {
+      font-size: 34px;
+      color: @accent;
+      filter: drop-shadow(0 0 10px @accent-glow);
+    }
+  }
 
   .signInBox {
-    aspect-ratio: 1/1;
-    background-color: #fff;
-    width: 512px;
-    max-width: 95%;
-    border-radius: 32px;
-    padding: 16px;
+    .surface-card();
+    width: 420px;
+    max-width: 100%;
+    padding: 36px 32px 32px;
+
+    .subtitle {
+      text-align: center;
+      color: @text-muted;
+      font-size: 14px;
+      font-weight: 600;
+      margin-bottom: 28px;
+    }
 
     form {
-      height: 100%;
       display: flex;
       flex-direction: column;
-      justify-content: space-evenly;
+      gap: 16px;
 
-      .input {
-        width: 100%;
-        padding: 16px;
-        border-radius: 32px;
-        flex: 1 0 auto;
-        margin: 16px 0;
+      .field {
+        display: flex;
+        align-items: center;
+        background: @bg-surface-raised;
+        border: 1px solid @border-strong;
+        border-radius: @radius-sm;
+        padding: 0 14px;
+        transition: border-color @transition-fast, background @transition-fast;
+
+        &:focus-within {
+          border-color: @accent;
+          background: @bg-surface-hover;
+        }
+
+        .fieldIcon {
+          font-size: 20px;
+          color: @text-dim;
+          flex-shrink: 0;
+        }
+
+        .input {
+          width: 100%;
+          background: transparent;
+          border: none;
+          outline: none;
+          color: @text-primary;
+          font-family: @font-body;
+          font-weight: 600;
+          padding: 14px 12px;
+
+          &::placeholder {
+            color: @text-dim;
+            font-weight: 500;
+          }
+        }
       }
 
       .submitButton {
-        width: 100%;
-        color: white;
-        padding: 16px;
-        border-radius: 32px;
-
-        &:not([disabled]) {
-          background-color: blueviolet;
-        }
-
-        &:disabled {
-          background-color: #e4afff !important;
-        }
+        .btn-primary();
+        border: none;
+        margin-top: 12px;
+        padding: 14px;
+        font-size: 15px;
+        text-transform: uppercase;
       }
     }
   }
 
   .copyright {
     text-align: center;
+    color: @text-dim;
+    font-size: 12px;
   }
 }

--- a/src/pages/signin/SignIn.tsx
+++ b/src/pages/signin/SignIn.tsx
@@ -6,6 +6,7 @@ import {useNavigate} from "react-router-dom";
 import {useContext, useEffect} from "react";
 import {UserContext} from "../../contexts/UserContext.tsx";
 import {FirebaseError} from "firebase/app";
+import {MdOutlineEmojiEvents, MdOutlineLock, MdOutlineMail} from "react-icons/md";
 
 type Inputs = {
     email: string;
@@ -44,15 +45,24 @@ const SignIn = () => {
 
     return (
         <div className={styles.container}>
+            <div className={styles.brand}>
+                <MdOutlineEmojiEvents className={styles.brandIcon}/>
+                <span>Points Tracker</span>
+            </div>
             <div className={styles.signInBox}>
+                <p className={styles.subtitle}>Log in om de stand bij te houden</p>
                 <form onSubmit={handleSubmit(onSubmit)}>
-                    <div>
+                    <label className={styles.field}>
+                        <MdOutlineMail className={styles.fieldIcon}/>
                         <input type="email" className={styles.input}
                                placeholder="Email" {...register("email", {required: true})} />
+                    </label>
+                    <label className={styles.field}>
+                        <MdOutlineLock className={styles.fieldIcon}/>
                         <input type="password" className={styles.input}
-                               placeholder="Password" {...register("password", {required: true})} />
-                    </div>
-                    <input type="submit" className={styles.submitButton}
+                               placeholder="Wachtwoord" {...register("password", {required: true})} />
+                    </label>
+                    <input type="submit" value="Inloggen" className={styles.submitButton}
                            disabled={Object.keys(dirtyFields).length === 0}/>
                 </form>
             </div>

--- a/src/styles/SharedSettingStyles.module.less
+++ b/src/styles/SharedSettingStyles.module.less
@@ -1,73 +1,174 @@
 .category {
+  .surface-card();
   flex: 1;
-
-  &:not(:last-child) {
-    border-right: 1px solid darkgray;
-  }
+  min-width: 280px;
+  max-width: 420px;
+  overflow: hidden;
 
   .itemContent {
     .listItem {
-      font-family: "Agency FB", serif;
-      font-size: 24px;
-      border-bottom: 1px solid darkgray;
-      padding: 16px;
+      font-family: @font-body;
+      font-weight: 600;
+      font-size: 15px;
+      color: @text-primary;
+      border-bottom: 1px solid @border-subtle;
+      padding: 14px 20px;
       display: flex;
       justify-content: space-between;
       align-items: center;
+      gap: 12px;
+      transition: background @transition-fast;
+
+      &:last-child {
+        border-bottom: none;
+      }
 
       small {
-        font-style: italic;
-        margin: 0 8px;
+        font-style: normal;
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        padding: 8px 12px;
+        border-radius: @radius-pill;
+        white-space: nowrap;
+        flex-shrink: 0;
+        cursor: pointer;
+      }
+
+      .activePill {
+        background: fade(@accent, 16%);
+        color: @accent;
+      }
+
+      .inactivePill {
+        background: transparent;
+        color: @text-dim;
+        border: 1px solid @border-strong;
 
         &:hover {
-          text-decoration: underline;
+          color: @text-primary;
+          border-color: @accent-dim;
         }
       }
 
       .name {
         display: flex;
         align-items: center;
+        gap: 6px;
+        flex: 1;
+        min-width: 0;
 
         .deleteIcon {
-          color: red;
-          margin-right: 8px;
-          display: none;
+          color: @text-dim;
+          flex-shrink: 0;
+          opacity: 0.6;
+          box-sizing: content-box;
+          padding: 10px;
+          margin: -10px;
+          font-size: 15px;
+          border-radius: 50%;
+          transition: color @transition-fast, opacity @transition-fast, background @transition-fast;
 
           &:hover {
-            color: darkred;
+            color: @danger;
+            opacity: 1;
+            background: fade(@danger, 12%);
+          }
+        }
+
+        .nameText {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          min-width: 0;
+        }
+
+        .editInput {
+          .text-input();
+          flex: 1;
+          min-width: 0;
+          padding: 6px 10px;
+          font-size: 15px;
+        }
+      }
+
+      .editIcon {
+        color: @text-dim;
+        opacity: 0.6;
+        flex-shrink: 0;
+        box-sizing: content-box;
+        padding: 10px;
+        margin: -10px;
+        font-size: 14px;
+        border-radius: 50%;
+        cursor: pointer;
+        transition: color @transition-fast, opacity @transition-fast, background @transition-fast;
+
+        &:hover {
+          color: @accent;
+          opacity: 1;
+          background: fade(@accent, 12%);
+        }
+      }
+
+      .editActions {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-shrink: 0;
+
+        .saveIcon, .cancelIcon {
+          box-sizing: content-box;
+          padding: 10px;
+          margin: -10px;
+          border-radius: 50%;
+          cursor: pointer;
+          transition: color @transition-fast, background @transition-fast;
+        }
+
+        .saveIcon {
+          color: @accent;
+
+          &:hover {
+            background: fade(@accent, 14%);
+          }
+        }
+
+        .cancelIcon {
+          color: @danger;
+
+          &:hover {
+            background: fade(@danger, 14%);
           }
         }
       }
 
-      &:hover .deleteIcon {
-        display: block;
+      > svg, > div > svg {
+        flex-shrink: 0;
       }
 
       &:hover:not(.active) {
         cursor: pointer;
+        background: @bg-surface-raised;
       }
 
       &:hover, &.active {
-        background-color: #cfc5bb;
+        background: @bg-surface-hover;
       }
 
       input[type="text"] {
-        border: none;
-        background-color: transparent;
-        padding: 8px;
-        outline: none;
+        .text-input();
         flex: 1;
+        min-width: 0;
+        padding: 8px 12px;
       }
 
       button {
-        border: none;
-        background-color: blueviolet;
-        padding: 8px;
-        border-radius: 8px;
-
-        &:hover {
-          background-color: #e4afff;
-        }
+        .btn-primary();
+        padding: 10px 16px;
+        font-size: 13px;
+        flex-shrink: 0;
       }
     }
   }

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,0 +1,154 @@
+// ---------------------------------------------------------------------------
+// Points Tracker design tokens — "Night Scoreboard" theme
+// Auto-imported (as reference) into every *.module.less file, see vite.config.ts
+// ---------------------------------------------------------------------------
+
+// Type
+@font-display: "Bebas Neue", "Arial Narrow", sans-serif;
+@font-body: "Manrope", "Segoe UI", sans-serif;
+
+// Surfaces
+@bg-void: #07080d;
+@bg-base: #0e0f17;
+@bg-surface: #171923;
+@bg-surface-raised: #1f2230;
+@bg-surface-hover: #262a3b;
+
+// Borders
+@border-subtle: rgba(255, 255, 255, 0.08);
+@border-strong: rgba(255, 255, 255, 0.16);
+
+// Text
+@text-primary: #f5f4ef;
+@text-muted: #9498ab;
+@text-dim: #62677d;
+
+// Accent — LED scoreboard green
+@accent: #c6ff35;
+@accent-dim: #8fbf1f;
+@accent-glow: rgba(198, 255, 53, 0.35);
+@on-accent: #0c1103;
+
+// Medal tones
+@medal-gold: #ffd60a;
+@medal-silver: #c7cfe0;
+@medal-bronze: #e0995e;
+
+// Danger
+@danger: #ff5468;
+@danger-dim: #c33e4d;
+
+// Radii
+@radius-sm: 8px;
+@radius-md: 14px;
+@radius-lg: 22px;
+@radius-pill: 999px;
+
+// Shadows
+@shadow-card: 0 4px 24px rgba(0, 0, 0, 0.45);
+@shadow-raised: 0 8px 32px rgba(0, 0, 0, 0.55);
+
+// Motion
+@ease: cubic-bezier(0.16, 1, 0.3, 1);
+@transition-fast: 0.15s @ease;
+@transition-base: 0.25s @ease;
+
+// ---------------------------------------------------------------------------
+// Mixins
+// ---------------------------------------------------------------------------
+
+.focus-ring() {
+  &:focus-visible {
+    outline: 2px solid @accent;
+    outline-offset: 2px;
+  }
+}
+
+.surface-card() {
+  background: @bg-surface;
+  border: 1px solid @border-subtle;
+  border-radius: @radius-lg;
+  box-shadow: @shadow-card;
+}
+
+.btn-reset() {
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.btn-primary() {
+  .btn-reset();
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: @accent;
+  color: @on-accent;
+  font-family: @font-body;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  padding: 12px 20px;
+  border-radius: @radius-pill;
+  transition: transform @transition-fast, box-shadow @transition-fast, background @transition-fast;
+  box-shadow: 0 0 0 rgba(198, 255, 53, 0);
+
+  &:hover:not(:disabled) {
+    box-shadow: 0 0 24px @accent-glow;
+    transform: translateY(-1px);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    background: @bg-surface-raised;
+    color: @text-dim;
+    cursor: not-allowed;
+  }
+}
+
+.btn-ghost() {
+  .btn-reset();
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: @text-muted;
+  border: 1px solid @border-strong;
+  padding: 10px 16px;
+  border-radius: @radius-pill;
+  font-family: @font-body;
+  font-weight: 700;
+  transition: color @transition-fast, border-color @transition-fast, background @transition-fast;
+
+  &:hover {
+    color: @text-primary;
+    border-color: @accent-dim;
+    background: rgba(198, 255, 53, 0.08);
+  }
+}
+
+.text-input() {
+  font-family: @font-body;
+  font-weight: 600;
+  color: @text-primary;
+  background: @bg-surface-raised;
+  border: 1px solid @border-strong;
+  border-radius: @radius-sm;
+  padding: 12px 14px;
+  transition: border-color @transition-fast, background @transition-fast;
+
+  &::placeholder {
+    color: @text-dim;
+    font-weight: 500;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: @accent;
+    background: @bg-surface-hover;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,18 @@
 import {defineConfig} from 'vite'
 import react from '@vitejs/plugin-react'
+import {fileURLToPath} from 'node:url'
+import {dirname, resolve} from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  css: {
+    preprocessorOptions: {
+      less: {
+        additionalData: `@import (reference) "${resolve(__dirname, 'src/styles/variables.less').split('\\').join('/')}";`
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- Full visual redesign ("Night Scoreboard" theme: dark charcoal + LED-green accent, Bebas Neue/Manrope typography) across sign-in, dashboard leaderboard, points entry, and settings pages
- Made settings pages mobile friendly: long event/team/game names now truncate instead of breaking row layout, and touch targets are bigger
- Added inline edit mode for events, teams, and games (rename in place with save/cancel)
- Settings pages now auto-select the currently active event instead of requiring a manual click
- Fixed a bug where the delete/edit icons rendered invisible (box-sizing/padding conflict collapsed them to 0x0)
- Included the dev-only `.env.development` (placeholder emulator config, safe to commit) and an updated `package-lock.json`

## Test plan
- [x] `tsc --noEmit` passes
- [x] Manually exercised sign-in, dashboard, points entry, and settings (incl. rename/edit, mobile viewport down to 320px) against the Firebase emulator with seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)